### PR TITLE
Fix tiled authentication

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -6,7 +6,7 @@ from tiled.client import from_profile
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym):
     logger = get_run_logger()
-    tiled_client = from_profile("nsls2", username=None)
+    tiled_client = from_profile("nsls2")
     run = tiled_client[beamline_acronym]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")
     start_time = ttime.monotonic()

--- a/processing.py
+++ b/processing.py
@@ -14,7 +14,7 @@ from rebin import rebin
 from tiled_io import _xs_ch_roi_keys, _xs_roi_combine_dict, _pil100k_roi_keys
 _external_detector_keys = _xs_ch_roi_keys + list(_xs_roi_combine_dict.keys()) + _pil100k_roi_keys
 
-tiled_client = from_profile("nsls2", username=None)["iss"]
+tiled_client = from_profile("nsls2")["iss"]
 tiled_client_iss = tiled_client["raw"]
 tiled_client_sandbox = tiled_client["sandbox"]
 


### PR DESCRIPTION
Specifying `username=None` in `from_profile` caused tiled to error out because both a tiled API key and username are provided.